### PR TITLE
Create Carousel component for home page

### DIFF
--- a/app/articles/_components/ArticleCard.tsx
+++ b/app/articles/_components/ArticleCard.tsx
@@ -31,7 +31,7 @@ const ArticleCard = ({ article, className }: Props) => {
 	console.log(article);
 	return (
 		<Link href={`articles/${article.id}`} className={className}>
-			<Box width="350px">
+			<Box width="calc(100vw - 42px)" maxWidth="350px" pb="6">
 				<Card className="shadow-lg">
 					<Inset clip="padding-box" side="top" pb="current">
 						<div className="absolute p-3 top-[90px] w-[100%]">

--- a/app/articles/_components/ArticleCard.tsx
+++ b/app/articles/_components/ArticleCard.tsx
@@ -15,6 +15,7 @@ import { FaBookmark } from "react-icons/fa6";
 
 interface Props {
 	article: Article;
+	className?: string;
 }
 
 type Article = {
@@ -26,10 +27,10 @@ type Article = {
 	internalUseOnly: boolean;
 };
 
-const ArticleCard = ({ article }: Props) => {
+const ArticleCard = ({ article, className }: Props) => {
 	console.log(article);
 	return (
-		<Link href={`articles/${article.id}`}>
+		<Link href={`articles/${article.id}`} className={className}>
 			<Box width="350px">
 				<Card className="shadow-lg">
 					<Inset clip="padding-box" side="top" pb="current">

--- a/app/components/carousel/Carousel.tsx
+++ b/app/components/carousel/Carousel.tsx
@@ -56,7 +56,6 @@ export const Carousel = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<Flex
 			justify={"between"}
-			height={"480px"}
 			align="center"
 			className="border-[1px] rounded-md"
 		>

--- a/app/components/carousel/Carousel.tsx
+++ b/app/components/carousel/Carousel.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Flex } from "@radix-ui/themes";
+import { HiChevronLeft, HiChevronRight } from "react-icons/hi2";
+import { useEffect, useRef, useCallback } from "react";
+import { NextPrevButton } from "./NextPrevButton";
+import styles from "./carousel.module.css";
+
+const SCROLL_INTO_VIEW_CONFIG: ScrollIntoViewOptions = {
+	behavior: 'smooth',
+	block: 'nearest',
+	inline: 'start'
+};
+
+export const Carousel = ({ children }: { children: React.ReactNode }) => {
+	const carouselRef = useRef<HTMLDivElement>(null);
+	const visibleChildrenRef = useRef<HTMLElement[]>([]);
+	const handleIntersect = (entries: IntersectionObserverEntry[]) => {
+		const updatedVisibleChildren = new Set(visibleChildrenRef.current);
+		entries.forEach(entry => {
+			if (entry.isIntersecting) {
+				updatedVisibleChildren.add(entry.target as HTMLElement);
+			} else {
+				updatedVisibleChildren.delete(entry.target as HTMLElement);
+			}
+		});
+
+		visibleChildrenRef.current = Array.from(updatedVisibleChildren).sort(
+			(a: HTMLElement, b: HTMLElement) => a.offsetLeft - b.offsetLeft
+		);
+	};
+
+	const nextItem = useCallback(() => {
+		const firstVisibleItem = visibleChildrenRef.current?.[0];
+		firstVisibleItem.nextElementSibling?.scrollIntoView(SCROLL_INTO_VIEW_CONFIG)
+	}, [visibleChildrenRef]);
+	const prevItem = useCallback(() => {
+		const firstVisibleItem = visibleChildrenRef.current?.[0];
+		firstVisibleItem.previousElementSibling?.scrollIntoView(SCROLL_INTO_VIEW_CONFIG)
+	}, [visibleChildrenRef]);
+
+	useEffect(() => {
+		const observer = new IntersectionObserver(handleIntersect, {
+			root: carouselRef.current,
+			rootMargin: "0px",
+			threshold: 0.75
+		});
+
+		Array.from(carouselRef.current?.children || []).forEach(el => {
+			observer.observe(el);
+		});
+
+		return () => observer.disconnect();
+	}, []);
+
+	return (
+		<Flex
+			justify={"between"}
+			height={"480px"}
+			align="center"
+			className="border-[1px] rounded-md"
+		>
+			<NextPrevButton onClick={prevItem}>
+				<HiChevronLeft size="24" />
+			</NextPrevButton>
+			<div className={styles.carousel} ref={carouselRef}>
+				{children}
+			</div>
+			<NextPrevButton onClick={nextItem}>
+				<HiChevronRight size="24" />
+			</NextPrevButton>
+		</Flex>
+	);
+}

--- a/app/components/carousel/NextPrevButton.tsx
+++ b/app/components/carousel/NextPrevButton.tsx
@@ -1,0 +1,13 @@
+import styles from "./carousel.module.css";
+
+export const NextPrevButton = ({ children, onClick }: { children: React.ReactNode, onClick: () => void }) => {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={styles.button}
+		>
+			{children}
+		</button>
+	);
+};

--- a/app/components/carousel/carousel.module.css
+++ b/app/components/carousel/carousel.module.css
@@ -1,0 +1,29 @@
+.carousel {
+    display: flex;
+    justify-content: flex-start;
+    gap: var(--space-4);
+    width: 100%;
+    overflow-x: scroll;
+    scroll-snap-type: x mandatory;
+}
+
+.button {
+    display: none;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+	height: 100%;
+	width: 50px;
+	align-items: center;
+	justify-content: center;
+}
+
+@media (min-width: 1024px) {
+    .button {
+        display: flex;
+    }
+}
+
+.item {
+    scroll-snap-align: start;
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import { HiChevronLeft, HiChevronRight } from "react-icons/hi2";
 import ArticleCard from "../articles/_components/ArticleCard";
 import fetchInterceptor from "../utils/fetchInterceptor";
+import { Carousel } from "../components/carousel/Carousel";
+import carouselStyles from "../components/carousel/carousel.module.css";
 
 const Home = async () => {
 	const competencies = await fetchInterceptor(
@@ -47,49 +49,13 @@ const Home = async () => {
 					<Text>Grouped by Competency</Text>
 				</Box>
 			</Flex>
-			<Flex
-				justify={"between"}
-				height={"480px"}
-				align="center"
-				className="border-[1px] rounded-md"
-			>
-				<Flex
-					id="carousel-1"
-					height={"100%"}
-					width={"50px"}
-					align="center"
-					justify={"center"}
-					display={{ initial: "none", md: "flex" }}
-				>
-					<HiChevronLeft size="24" />
-				</Flex>
 
-				<Flex height={"100%"} width={"93%"} gap="4" position={"relative"}>
-					<Flex
-						position={"absolute"}
-						width={"100%"}
-						height={"100%"}
-						gap="4"
-						overflowX={"scroll"}
-						overflowY={"hidden"}
-					>
-						{articles &&
-							articles.map((article: Article) => (
-								<ArticleCard key={article.id} article={article} />
-							))}
-					</Flex>
-				</Flex>
-
-				<Flex
-					height={"100%"}
-					width={"50px"}
-					align="center"
-					justify={"center"}
-					display={{ initial: "none", md: "flex" }}
-				>
-					<HiChevronRight size="24" />
-				</Flex>
-			</Flex>
+			<Carousel>
+				{articles &&
+					articles.map((article: Article) => (
+						<ArticleCard key={article.id} article={article} className={carouselStyles.item} />
+					))}
+			</Carousel>
 
 			<Flex mt="5" mb="3">
 				<Box>
@@ -97,48 +63,12 @@ const Home = async () => {
 					<Text>The articles you saved for later</Text>
 				</Box>
 			</Flex>
-			<Flex
-				justify={"between"}
-				height={"480px"}
-				align="center"
-				className="border-[1px] rounded-md"
-			>
-				<Flex
-					height={"100%"}
-					width={"50px"}
-					align="center"
-					justify={"center"}
-					display={{ initial: "none", md: "flex" }}
-				>
-					<HiChevronLeft size="24" />
-				</Flex>
-
-				<Flex height={"100%"} width={"93%"} gap="4" position={"relative"}>
-					<Flex
-						position={"absolute"}
-						width={"100%"}
-						height={"100%"}
-						gap="4"
-						overflowX={"scroll"}
-						overflowY={"hidden"}
-					>
-						{myArticles &&
-							myArticles.map((article: Article) => (
-								<ArticleCard key={article.id} article={article} />
-							))}
-					</Flex>
-				</Flex>
-
-				<Flex
-					height={"100%"}
-					width={"50px"}
-					align="center"
-					justify={"center"}
-					display={{ initial: "none", md: "flex" }}
-				>
-					<HiChevronRight size="24" />
-				</Flex>
-			</Flex>
+			<Carousel>
+				{myArticles &&
+					myArticles.map((article: Article) => (
+						<ArticleCard key={article.id} article={article} />
+					))}
+			</Carousel>
 			<div className="flex flex-col-mt-10"></div>
 		</main>
 	);

--- a/app/my/articles/page.tsx
+++ b/app/my/articles/page.tsx
@@ -6,6 +6,7 @@ import ArticleCard from "../../articles/_components/ArticleCard";
 import fetchInterceptor from "../../utils/fetchInterceptor";
 import { headers } from "next/headers";
 import { FaBookmark } from "react-icons/fa6";
+import { Carousel } from "@/app/components/carousel/Carousel";
 
 interface Article {
 	id: string;
@@ -77,56 +78,34 @@ export default async function MyArticles() {
 						<Text>Grouped by Competency</Text>
 					</Box>
 				</Flex>
-				<Flex className="overflow-y-hidden overflow-x-scroll" p="3" px="5">
-					<div className="absolute bg-white py-[11%] w-[50px] z-10 ml-[-50px] mt-[-10px] invisible md:visible">
-						<HiChevronLeft size="3x" />
-					</div>
-					<Flex gap="4" width="100%" justify="start">
-						{myArticles.length === 0 && (
-							<Flex>
-								<Text>Here you should see some articles</Text>
-							</Flex>
-						)}
-
-						{myArticles.map((article: Article) => (
-							<Flex>
-								<FaBookmark
-									size="22"
-									className="absolute top-3 right-3 z-50"
-									color="cyan"
-								/>
-								<ArticleCard key={article.id} article={article} />
-							</Flex>
-						))}
-					</Flex>
-					<div className="absolute bg-white py-[11%] w-[40px] z-10 right-0 mr-[30px] mt-[-10px] invisible md:visible">
-						<HiChevronRight size="3x" />
-					</div>
-				</Flex>
+				<Carousel>
+					{myArticles.map((article: Article) => (
+						<Flex>
+							<FaBookmark
+								size="22"
+								className="absolute top-3 right-3 z-50"
+								color="cyan"
+							/>
+							<ArticleCard key={article.id} article={article} />
+						</Flex>
+					))}
+				</Carousel>
 				<Flex mt="5" mb="3">
 					<Box>
 						<Heading>Top Related Learning Activities</Heading>
 						<Text>What's trending</Text>
 					</Box>
 				</Flex>
-				<Flex className="overflow-y-hidden overflow-x-scroll" p="3">
-					<div className="absolute bg-white py-[11%] w-[50px] z-10 ml-[-50px] mt-[-10px] invisible md:visible">
-						<HiChevronLeft size="3x" />
-					</div>
-					<Flex gap="4" width="100%" justify="start">
-						{suggestedArticles.length === 0 && (
-							<Flex>
-								<Text>Here you should see some articles</Text>
-							</Flex>
-						)}
-						{suggestedArticles.map((article: Article) => (
-							<ArticleCard key={article.id} article={article} />
-						))}
-					</Flex>
-					<div className="absolute bg-white py-[11%] w-[40px] z-10 right-0 mr-[30px] mt-[-10px] invisible md:visible">
-						<HiChevronRight size="3x" />
-					</div>
-				</Flex>
+				<Carousel>
+					{suggestedArticles.length === 0 && (
+						<Flex>
+							<Text>Here you should see some articles</Text>
+						</Flex>
+					)}
+					{suggestedArticles.map((article: Article) => (
+						<ArticleCard key={article.id} article={article} />
+					))}
+				</Carousel>
 				<div className="flex flex-col-mt-10"></div>
 			</main>
 		</>


### PR DESCRIPTION
This creates a `<Carousel>` client component that enables horizontal scrolling between children elements with native CSS scroll snapping and next/previous buttons that scroll one item at a time.

The [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) keeps track of the currently visible children elements and uses the DOM to find the next/previous element to smoothly scroll into view suing the native, hardware accelerate [`scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) function.

The Carousel component is implemented in two places on the home page to scroll `<ArticleCards>`.

## Demo

https://github.com/user-attachments/assets/f8869c67-b76b-4606-9695-a0fd2499fa97


