### PR TITLE
Parallelize & simplify API requests for performance

### DIFF
--- a/app/Navbar.tsx
+++ b/app/Navbar.tsx
@@ -4,16 +4,14 @@ import { Flex } from "@radix-ui/themes";
 import DesktopNavLinks from "./components/navbar/DesktopNavLinks";
 import MobileNavLinks from "./components/navbar/MobileNavLinks";
 import AvatarBox from "./components/navbar/AvatarBox";
-import fetchInterceptor from "./utils/fetchInterceptor";
+import { fetchApi } from "./utils/fetchInterceptor";
 import { hasCookie } from "cookies-next";
 import { cookies } from "next/headers";
 
 const Navbar = async () => {
 	const userSession = await hasCookie("jwt", { cookies });
 	if (userSession) {
-		const loggedUser = await fetchInterceptor(
-			`${process.env.NEXT_PUBLIC_APIBASE}/my/profile`
-		);
+		const loggedUser = await fetchApi(`/my/profile`);
 		return (
 			<nav className="p-0 m-0 overflow-x-hidden">
 				<Flex direction="column">

--- a/app/articles/[id]/edit/page.tsx
+++ b/app/articles/[id]/edit/page.tsx
@@ -1,31 +1,28 @@
 import { Container, Flex, Heading } from "@radix-ui/themes";
 import React from "react";
 import EditArticleForm from "../../_components/EditArticleForm";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 
 const EditArticlePage = async (props: { params: Promise<{ id: string }> }) => {
 	const params = await props.params;
-	const article = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/articles/" + params.id
-	);
-	const educationalFrameworks = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/educational-frameworks"
-	);
-	const educationalMethodolodies = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/educational-methodologies"
-	);
-	const medias = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/media"
-	);
-	const languages = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/languages"
-	);
-	const sources = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/sources"
-	);
-	const educationalTools = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/educational-tools"
-	);
+
+	const [
+		article,
+		educationalFrameworks,
+		educationalMethodolodies,
+		medias,
+		languages,
+		sources,
+		educationalTools,
+	] = await Promise.all([
+		fetchApi("/articles/" + params.id),
+		fetchApi("/educational-frameworks"),
+		fetchApi("/educational-methodologies"),
+		fetchApi("/media"),
+		fetchApi("/languages"),
+		fetchApi("/sources"),
+		fetchApi("/educational-tools")
+	]);
 
 	return (
 		<Flex

--- a/app/articles/[id]/page.tsx
+++ b/app/articles/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
 import React, { Suspense } from "react";
 import Link from "next/link";
 import { isAuthorized } from "@/app/utils/roleRules";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import DownloadFile from "../_components/DownloadFile";
 import PinArticleButton from "../_components/PinArticleButton";
 import ArticleRelevanceForJobTitleSkills from "../_components/ArticleRelevanceForJobTitleSkills";
@@ -26,9 +26,7 @@ const ArticlePage = async (props: { params: Promise<{ id: string }> }) => {
 	// await new Promise((resolve) => setTimeout(resolve, 2000));
 	const params = await props.params;
 	const id = params.id;
-	const article = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/articles/${id}`
-	);
+	const article = await fetchApi(`/articles/${id}`);
 	return (
 		<Container my={{ initial: "0", md: "5" }} p={{ initial: "4", md: "0" }}>
 			<Flex justify="end" mb="3">

--- a/app/articles/_components/ArticleRelevanceForJobTitleSkills.tsx
+++ b/app/articles/_components/ArticleRelevanceForJobTitleSkills.tsx
@@ -1,4 +1,4 @@
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import ( fetchApi ) from "@/app/utils/fetchInterceptor";
 import { Flex, Tabs, Text, Box, Heading } from "@radix-ui/themes";
 import React from "react";
 
@@ -12,12 +12,8 @@ const ArticleRelevanceForJobTitleSkills = async ({
 }: {
 	article: Article;
 }) => {
-	const jobTitleSkills = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/job-title-skills`
-	);
-	const jobTitleSkills = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/job-title-skills`
-	);
+	const jobTitleSkills = await fetchApi(`/job-title-skills`);
+
 	return (
 		<Flex direction={"column"} gap="4">
 			<Heading size="3" weight={"bold"}>

--- a/app/articles/new/page.tsx
+++ b/app/articles/new/page.tsx
@@ -1,27 +1,25 @@
 import { Container, Heading, Text } from "@radix-ui/themes";
 import React from "react";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import NewArticleForm from "../_components/NewArticleForm";
 
 const NewArticle = async () => {
-	const educationalFrameworks = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/educational-frameworks"
-	);
-	const educationalMethodolodies = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/educational-methodologies"
-	);
-	const medias = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/media"
-	);
-	const languages = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/languages"
-	);
-	const sources = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/sources"
-	);
-	const educationalTools = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/educational-tools"
-	);
+	const [
+		educationalFrameworks,
+		educationalMethodolodies,
+		medias,
+		languages,
+		sources,
+		educationalTools,
+	] = await Promise.all([
+		fetchApi("/educational-frameworks"),
+		fetchApi("/educational-methodologies"),
+		fetchApi("/media"),
+		fetchApi("/languages"),
+		fetchApi("/sources"),
+		fetchApi("/educational-tools"),
+	]);
+	
 	return (
 		<Container my="5">
 			<Heading>New article</Heading>

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -12,24 +12,18 @@ import {
 } from "@radix-ui/themes";
 import React, { Suspense } from "react";
 import Link from "next/link";
-import fetchInterceptor from "../utils/fetchInterceptor";
+import { fetchApi } from "../utils/fetchInterceptor";
 import ArticlesTable from "./_components/ArticlesTable";
 import { InfoCircledIcon } from "@radix-ui/react-icons";
 import SyncKnowledge from "../my/chats/_components/SyncKnowledge";
 
 const ArticlesPage = async () => {
-	const articles = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/articles"
-	);
+	const articles = await fetchApi("/articles");
 
-	let ingestionJob = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/chatbot/ingestion-jobs/last`
-	);
+	let ingestionJob = await fetchApi(`/chatbot/ingestion-jobs/last`);
 
 	const fetchStatus = () => {
-		ingestionJob = fetchInterceptor(
-			`${process.env.NEXT_PUBLIC_APIBASE}/chatbot/ingestion-jobs/last`
-		);
+		ingestionJob = fetchApi(`/chatbot/ingestion-jobs/last`);
 	};
 	console.log(ingestionJob);
 	return (

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -3,18 +3,19 @@ import Link from "next/link";
 import React from "react";
 import { HiChevronLeft, HiChevronRight } from "react-icons/hi2";
 import ArticleCard from "../articles/_components/ArticleCard";
-import fetchInterceptor from "../utils/fetchInterceptor";
+import { fetchApi } from "../utils/fetchInterceptor";
 
 const Home = async () => {
-	const competencies = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/competencies"
-	);
-	const articles = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/articles"
-	);
-	const myArticles = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/articles/pinned"
-	);
+	const [
+		competencies,
+		articles,
+		myArticles,
+	] = await Promise.all([
+		fetchApi("/competencies"),
+		fetchApi("/articles"),
+		fetchApi("/my/articles/pinned")
+	]);
+	
 	const colors = ["bg-primary", "bg-secondary", "bg-tertiary", "bg-quartery"];
 	return (
 		<main className="flex flex-col p-5">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import localFont from "next/font/local";
 import { Flex, Box, Grid, Section, Theme, Text } from "@radix-ui/themes";
 import Navbar from "./Navbar";
 import AskMaestro from "./components/AskMaestro";
-import fetchInterceptor from "./utils/fetchInterceptor";
+import { fetchApi } from "./utils/fetchInterceptor";
 import { Suspense } from "react";
 import NewChat from "./my/chats/_components/NewChat";
 import { ToastContainer } from "react-toastify";
@@ -22,9 +22,7 @@ export default async function RootLayout({
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	const user = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/profile/"
-	);
+	const user = await fetchApi("/my/profile/");
 	return (
 		<html lang="en" className="dm_sans.className">
 			<body className={"flex flex-col m-0 p-0"}>

--- a/app/my/articles/page.tsx
+++ b/app/my/articles/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import React from "react";
 import { HiChevronLeft, HiChevronRight } from "react-icons/hi2";
 import ArticleCard from "../../articles/_components/ArticleCard";
-import fetchInterceptor from "../../utils/fetchInterceptor";
+import { fetchApi } from "../../utils/fetchInterceptor";
 import { headers } from "next/headers";
 import { FaBookmark } from "react-icons/fa6";
 
@@ -25,15 +25,15 @@ interface Competency {
 }
 
 export default async function MyArticles() {
-	const competencies = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/competencies"
-	);
-	const myArticles = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/articles/pinned"
-	);
-	const suggestedArticles = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/articles/suggested"
-	);
+	const [
+		competencies,
+		myArticles,
+		suggestedArticles,
+	] = await Promise.all([
+		fetchApi("/competencies"),
+		fetchApi("/my/articles/pinned"),
+		fetchApi("/my/articles/suggested")
+	]);
 
 	const colors = ["bg-primary", "bg-secondary", "bg-tertiary", "bg-quartery"];
 	// await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/app/my/assessments/_components/CompetencyModal.tsx
+++ b/app/my/assessments/_components/CompetencyModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "@radix-ui/themes";
 import React from "react";
 import Skill from "./Skill";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import BarChart from "./BarChart";
 
 interface Props {
@@ -28,9 +28,7 @@ type AssessmentResult = {
 const CompetencyModal = async ({ params, assessmentResults, color }: Props) => {
 	const results: AssessmentResult[] = assessmentResults;
 	const id = params.id;
-	const competency = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/competencies/" + id
-	);
+	const competency = await fetchApi("/competencies/" + id);
 	const assessmentValues = [];
 	const average = (array) =>
 		array.reduce((sum, currentValue) => sum + currentValue, 0) / array.length;

--- a/app/my/assessments/_components/Skill.tsx
+++ b/app/my/assessments/_components/Skill.tsx
@@ -1,13 +1,11 @@
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import { Grid, Text, Tooltip } from "@radix-ui/themes";
 import React from "react";
 
 const Skill = async ({ params, assessmentResults }: Props) => {
 	const userJobTitleId = "5b53f32b-5a49-402d-a146-480cd49e14e6";
 	const id = params.id;
-	const skill = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/skills/" + id
-	);
+	const skill = await fetchApi("/skills/" + id);
 
 	return (
 		<Grid columns="2" gap="3" align="center" mb="3">

--- a/app/my/assessments/new/page.tsx
+++ b/app/my/assessments/new/page.tsx
@@ -1,16 +1,19 @@
 import { Flex } from "@radix-ui/themes";
 import React from "react";
 import AssessmentForm from "../_components/AssessmentForm";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 
 const NewAssessment = async () => {
-	const jobTitleSkills = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/job-title-skills"
-	);
 	const userId = "d637ba80-30a1-477e-9e07-0894795344c9";
-	const user = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/users/" + userId
-	);
+
+	const [
+		jobTitleSkills,
+		user,
+	] = await Promise.all([
+		fetchApi("/job-title-skills"),
+		fetchApi("/users/" + userId),
+	]);
+	
 	return (
 		<Flex>
 			<AssessmentForm jobTitleSkills={jobTitleSkills} user={user} />

--- a/app/my/assessments/page.tsx
+++ b/app/my/assessments/page.tsx
@@ -2,7 +2,7 @@ import { Flex, Heading, Grid, Button, Box, Tooltip } from "@radix-ui/themes";
 import CompetencyModal from "./_components/CompetencyModal";
 import React from "react";
 import Link from "next/link";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 
 interface Competency {
 	id: string;
@@ -32,12 +32,14 @@ type tParams = Promise<{ slug: string[] }>;
 
 const AssessmentPage = async (props: { params: tParams }) => {
 	let id = await props.params;
-	const competencies = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/competencies"
-	);
-	const assessment = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/assessments/"
-	);
+	const [
+		competencies,
+		assessment,
+	] = await Promise.all([
+		fetchApi(`/competencies`),
+		fetchApi(`/my/assessments/`),
+	]);
+
 	const colors = ["bg-primary", "bg-secondary", "bg-tertiary", "bg-quartery"];
 	console.log(assessment);
 	return (

--- a/app/my/chats/[id]/page.tsx
+++ b/app/my/chats/[id]/page.tsx
@@ -2,7 +2,7 @@ import { Flex, Heading, Text, Grid, Separator } from "@radix-ui/themes";
 import React, { Suspense } from "react";
 import Sidebar from "../_components/Sidebar";
 import Chatbot from "../_components/Chatbot";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import { CiUser } from "react-icons/ci";
 import { RiRobot2Line } from "react-icons/ri";
 import Message from "../_components/Message";
@@ -16,9 +16,7 @@ type Message = {
 const ChatPage = async ({ params }: { params: Promise<{ id: string }> }) => {
 	const id = (await params).id;
 	console.log(id);
-	const chat = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/my/chats/${id}`
-	);
+	const chat = await fetchApi(`/my/chats/${id}`);
 	return (
 		<Flex className="w-[100%] min-w-[100%]" width={"100%"} minHeight={"80vh"}>
 			<Sidebar />

--- a/app/my/chats/_components/Sidebar.tsx
+++ b/app/my/chats/_components/Sidebar.tsx
@@ -2,12 +2,10 @@ import { BookmarkIcon, LightningBoltIcon } from "@radix-ui/react-icons";
 import { Flex, Box, Card, Text, Heading } from "@radix-ui/themes";
 import React, { cache } from "react";
 import Chatslist from "./ChatsList";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 
 const Sidebar = async () => {
-	const chats = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/chats"
-	);
+	const chats = await fetchApi("/my/chats");
 	return (
 		<>
 			<Flex

--- a/app/my/profile/_components/BookmarkedArticles.tsx
+++ b/app/my/profile/_components/BookmarkedArticles.tsx
@@ -1,12 +1,10 @@
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import { Flex, Heading, Text } from "@radix-ui/themes";
 import React from "react";
 import LinkBookmarkedArticle from "./LinkBookmarkedArticle";
 
 const BookmarkedArticles = async () => {
-	const myArticles: Article[] = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/my/articles/pinned`
-	);
+	const myArticles: Article[] = await fetchApi(`/my/articles/pinned`);
 	return (
 		<Flex direction={"column"}>
 			{myArticles.length === 0 ? (

--- a/app/my/profile/page.tsx
+++ b/app/my/profile/page.tsx
@@ -1,4 +1,4 @@
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import AssessementsTable from "../assessments/_components/LatestAssessment";
 import {
 	Avatar,
@@ -20,12 +20,14 @@ import UserDetailsCard from "./_components/UserDetailsCard";
 import BookmarkedArticles from "./_components/BookmarkedArticles";
 
 const MyProfile = async () => {
-	const user = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/profile"
-	);
-	const assessment = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/my/assessment"
-	);
+	const [
+		user,
+		assessment,
+	] = await Promise.all([
+		fetchApi(`/my/profile`),
+		fetchApi(`/my/assessment`),
+	]);
+
 	let roles = [""];
 	user.roleUsers.map((role: { role: { name: any } }) =>
 		roles.push(role.role.name)

--- a/app/mylibrary/page.tsx
+++ b/app/mylibrary/page.tsx
@@ -2,16 +2,19 @@ import { Box, Flex, Grid } from "@radix-ui/themes";
 import React, { Suspense } from "react";
 import ArticleCard from "../articles/_components/ArticleCard";
 import FilterSideBar from "./FilterSideBar";
-import fetchInterceptor from "../utils/fetchInterceptor";
+import { fetchApi } from "../utils/fetchInterceptor";
 
 const MyLibrary = async () => {
 	await new Promise((resolve) => setTimeout(resolve, 2000));
-	const articles = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/articles"
-	);
-	const competencies = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/competencies"
-	);
+
+	const [
+		articles,
+		competencies,
+	] = await Promise.all([
+		fetchApi(`/articles`),
+		fetchApi(`/competencies`),
+	]);
+
 	return (
 		<Grid
 			columns={{ initial: "1", md: "4" }}

--- a/app/users/[id]/edit/page.tsx
+++ b/app/users/[id]/edit/page.tsx
@@ -2,29 +2,26 @@ import React from "react";
 import UserForm from "../../_components/UserForm";
 import { Container, Flex, Heading } from "@radix-ui/themes";
 import { notFound, useSearchParams } from "next/navigation";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 
 const EditUserPage = async (props: { params: Promise<{ id: string }> }) => {
 	const params = await props.params;
 	let id = params.id;
-	const user = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/users/${id}`
-	);
-	const businessUnits = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/business-units/`
-	);
-	const languages = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/languages/`
-	);
-	const regions = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/regions/`
-	);
-	const jobTitles = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/job-titles/`
-	);
-	const roles = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/roles/`
-	);
+	const [
+		user,
+		businessUnits,
+		languages,
+		regions,
+		jobTitles,
+		roles,
+	] = await Promise.all([
+		fetchApi(`/users/${id}`),
+		fetchApi(`/business-units/`),
+		fetchApi(`/languages/`),
+		fetchApi(`/regions/`),
+		fetchApi(`/job-titles/`),
+		fetchApi(`/roles/`),
+	]);
 
 	if (!user) notFound();
 

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 import UserAvatar from "@/app/my/profile/_components/UserAvatar";
 import UserDetailsCard from "@/app/my/profile/_components/UserDetailsCard";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import {
 	Badge,
 	Button,
@@ -18,9 +18,7 @@ import DeleteUserModal from "../_components/DeleteUserModal";
 const UserPage = async (props: { params: Promise<{ id: string }> }) => {
 	const params = await props.params;
 	const id = params.id;
-	const user = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/users/${id}`
-	);
+	const user = await fetchApi(`/users/${id}`);
 	console.log(user);
 	return (
 		<Container py={"50px"}>

--- a/app/users/new/page.tsx
+++ b/app/users/new/page.tsx
@@ -1,24 +1,23 @@
 import { Container, Flex } from "@radix-ui/themes";
 import React from "react";
 import UserForm from "../_components/UserForm";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 
 const NewUser = async () => {
-	const businessUnits = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/business-units`
-	);
-	const languages = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/languages`
-	);
-	const regions = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/regions`
-	);
-	const jobTitles = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/job-titles`
-	);
-	const roles = await fetchInterceptor(
-		`${process.env.NEXT_PUBLIC_APIBASE}/roles`
-	);
+	const [
+		businessUnits,
+		languages,
+		regions,
+		jobTitles,
+		roles,
+	] = await Promise.all([
+		fetchApi("/business-units"),
+		fetchApi("/languages"),
+		fetchApi("/regions"),
+		fetchApi("/job-titles"),
+		fetchApi("/roles"),
+	]);
+
 	return (
 		<Container className="my-[40px] max-w-[600px] mx-auto border-[1px] shadow-md p-5">
 			<UserForm

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -2,7 +2,7 @@ import { Button, Container, Flex, Heading, Separator } from "@radix-ui/themes";
 import React, { Suspense } from "react";
 import UsersTable from "./_components/UsersTable";
 import Link from "next/link";
-import fetchInterceptor from "../utils/fetchInterceptor";
+import { fetchApi } from "../utils/fetchInterceptor";
 
 const Users = async (props: {
 	searchParams?: Promise<{
@@ -13,9 +13,7 @@ const Users = async (props: {
 	const searchParams = await props.searchParams;
 	const query = searchParams?.query || "";
 	const currentPage = Number(searchParams?.page) || 1;
-	const users = await fetchInterceptor(
-		process.env.NEXT_PUBLIC_APIBASE + "/users"
-	);
+	const users = await fetchApi("/users");
 	await new Promise((resolve) => setTimeout(resolve, 2000));
 
 	return (

--- a/app/utils/fetchInterceptor.ts
+++ b/app/utils/fetchInterceptor.ts
@@ -3,15 +3,18 @@ import { cookies } from "next/headers";
 const fetchInterceptor = async (url: string) => {
   const jwt = await (await cookies()).get("jwt")
   const data = await fetch(url, {
-      headers: {
-    Accept: "application/json",
-    Authorization:
-      "Bearer " + jwt?.value ,
-  },
-  cache: "no-store"
+    headers: {
+      Accept: "application/json",
+      Authorization:
+        "Bearer " + jwt?.value ,
+    },
+    cache: "no-store"
   });
   const res = await data.json();
   return (res);
 }
 
 export default fetchInterceptor;
+
+export const fetchApi = (url: string) =>
+  fetchInterceptor(`${process.env.NEXT_PUBLIC_APIBASE}${url}`);


### PR DESCRIPTION
This refactors all pages that `await` multiple `fetchInterceptor` to use a [`Promise.all()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all), as otherwise API requests are [serialized](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#patterns) instead of [parallelized](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#parallel-data-fetching), which increases the page load time for any uncached reuqests.

This also create simplified `fetchApi` that includes base URL. This way one doesn't have to prepend every URL with
`${process.env.NEXT_PUBLIC_APIBASE}/`.