### PR TITLE
Improve logged out state

### DIFF
--- a/app/Navbar.tsx
+++ b/app/Navbar.tsx
@@ -7,10 +7,11 @@ import AvatarBox from "./components/navbar/AvatarBox";
 import { fetchApi } from "./utils/fetchInterceptor";
 import { hasCookie } from "cookies-next";
 import { cookies } from "next/headers";
+import { getJwt, hasJwtExpired, mightBeLoggedIn } from "./utils/auth";
+import { Toast } from "./components/ClientToast";
 
 const Navbar = async () => {
-	const userSession = await hasCookie("jwt", { cookies });
-	if (userSession) {
+	if (await mightBeLoggedIn()) {
 		const loggedUser = await fetchApi(`/my/profile`);
 		const userRoles = loggedUser.roleUsers;
 		let roles: string[] = [];
@@ -50,6 +51,12 @@ const Navbar = async () => {
 				</Flex>
 			</nav>
 		);
+	}
+
+	const hasJwt = await getJwt();
+	const isJwtExpired = await hasJwtExpired();
+	if (hasJwt && isJwtExpired) {
+		return <Toast type="warning" message="Login has expired" />;
 	}
 };
 

--- a/app/components/ClientToast.tsx
+++ b/app/components/ClientToast.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "react-toastify";
+import type { TypeOptions } from "react-toastify";
+
+type ToastProps = {
+    type: Exclude<TypeOptions, 'default'>;
+    message: string;
+};
+
+export const Toast = ({ type, message }: ToastProps) => {
+    useEffect(() => {
+        toast[type](message);
+    }, [type, message]);
+
+    return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,13 +23,12 @@ export default async function RootLayout({
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	const user = await fetchApi("/my/profile/");
 	return (
 		<html lang="en" className="dm_sans.className">
 			<body className={"flex flex-col m-0 p-0"}>
 				<ToastContainer />
 				<Theme accentColor="red" radius="small" appearance="light">
-					<Navbar user={user} />
+					<Navbar />
 					<main className="flex-auto min-h-[80vh]">
 						<Suspense>{children}</Suspense>
 					</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import "@radix-ui/themes/styles.css";
+import 'react-toastify/dist/ReactToastify.css';
 import "./globals.css";
 import type { Metadata } from "next";
 import localFont from "next/font/local";

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -1,0 +1,23 @@
+import { toast } from "react-toastify";
+import { getCookie } from "./cookies";
+
+export const getJwt = () => getCookie("jwt");
+
+export const hasJwtExpired = async () => {
+    const jwt = await getJwt();
+
+    if (!jwt) return true;
+
+    try {
+        const [_header, payload, _signature] = jwt.split('.');
+
+        const { exp } = JSON.parse(atob(payload));
+        const expiryTimestamp = exp * 1000;
+        return expiryTimestamp <= Date.now();
+    } catch (error) {
+        console.error("Can't decode JWT token");
+        return true;
+    }
+}
+
+export const mightBeLoggedIn = async () => !(await hasJwtExpired());

--- a/app/utils/cookies.ts
+++ b/app/utils/cookies.ts
@@ -1,0 +1,15 @@
+import { getCookie as getCookieClient } from "cookies-next";
+import { isServer } from "./environment";
+
+/**
+ * Isomorphic cookie getter works both on server & client (components)
+ */
+export const getCookie = async (name: string) => {
+    if (isServer) {
+        const { cookies } = await import("next/headers");
+		const cookieStore = await cookies();
+		return cookieStore.get("jwt")?.value;
+    }
+
+    return getCookieClient(name);
+}

--- a/app/utils/environment.ts
+++ b/app/utils/environment.ts
@@ -1,0 +1,1 @@
+export const isServer = typeof window === 'undefined';


### PR DESCRIPTION
## 1e29c7e Import default Toastify styling

Feel free to customize how you see fit.

## a79d252 Create isomorphic cookie utility

The `getCookie` utility can be used both in server and client components
and the `isServer` utility can be used to determine if we are on the
server or in the client (browser).

## 7f81906 Remove unused profile fetch from layout

No need to fetch the profile here, as the NavBar already fetches it and
doesn't accept a `user` prop, so it's an unnecessary fetch and it does
crash on the `/login` page when the token is missing or has expired.

## 50ea264 Create toast client component

This makes it easy to trigger a toast once per mount even from a server
component, as the `<Toast>` is a client component.

## 8b689a9 Check if token expired to improve logged in check

Don't just check that if there is a JWT token, but also check if the
token has expired and in that case show a Toast that the login has
expired:

<img width="551" alt="Screenshot 2024-12-21 at 14 24 00" src="https://github.com/user-attachments/assets/eaba7597-eaf0-4c63-b1a5-4b30aa9d2147" />

Note that it's very important to not rely on `mightBeLoggedIn` fully.
Only the backend can validate the token signature to guarantee if the
user is authenticated correctly. The function `mightBeLoggedIn` can only
serve as a hint that the user is probably _not_ logged in. Even if it
returns `true` the API may still return a `401 Unauthorized`.