### PR TITLE
Improve general API and chat(bot) error handling

### DIFF
--- a/app/components/AskMaestro.tsx
+++ b/app/components/AskMaestro.tsx
@@ -1,11 +1,12 @@
 "use client";
+
 import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
 import { Box, Button, Flex, TextField } from "@radix-ui/themes";
 import { Formik, Form, Field } from "formik";
 import { usePathname, useRouter } from "next/navigation";
-import React from "react";
+import React, { useCallback } from "react";
 import { HiOutlineDocumentSearch } from "react-icons/hi";
-import { fetchApi } from "../utils/fetchInterceptor";
+import { startNewChat } from "../utils/api/chats";
 
 const AskMaestro = () => {
 	const router = useRouter();
@@ -20,37 +21,22 @@ const AskMaestro = () => {
 		console.log(result);
 		return result;
 	};
+
+	const onSubmit = useCallback(async ({ name: prompt } : { name: string }) => {
+		const chat = await startNewChat(prompt);
+
+		if (chat?.id) {
+			router.push(`/my/chats/${chat?.id}`);
+		}
+	}, []);
+
 	return (
 		<Flex mb="3" px="3">
 			<Formik
 				initialValues={{
 					name: "",
 				}}
-				onSubmit={async (values) => {
-					console.log(JSON.stringify(values));
-					const chat = await fetchApi(
-						"/my/chats/",
-						{
-							method: "POST",
-							body: JSON.stringify(values)
-						}
-					);
-					console.log(chat);
-					console.log(JSON.stringify({ chatId: chat.id, prompt: values.name }));
-					try {
-						const question = await fetchApi(
-							"/chatbot/ask",
-							{
-								method: "POST",
-								body: JSON.stringify({ chatId: chat.id, prompt: values.name })
-							}
-						);
-					} catch (error) {
-						console.log(error);
-					}
-					router.push(`/my/chats/${chat.id}`);
-					// if (newChat) redirect("/my/chats");
-				}}
+				onSubmit={onSubmit}
 			>
 				<Form className="w-[100%]">
 					<Flex

--- a/app/components/AskMaestro.tsx
+++ b/app/components/AskMaestro.tsx
@@ -1,16 +1,14 @@
 "use client";
 import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
 import { Box, Button, Flex, TextField } from "@radix-ui/themes";
-import { getCookie } from "cookies-next";
 import { Formik, Form, Field } from "formik";
 import { usePathname, useRouter } from "next/navigation";
-import router from "next/router";
 import React from "react";
 import { HiOutlineDocumentSearch } from "react-icons/hi";
+import { fetchApi } from "../utils/fetchInterceptor";
 
 const AskMaestro = () => {
 	const router = useRouter();
-	const jwt = getCookie("jwt");
 	const pathname = usePathname();
 	const blockedRoutes = ["/my/chats", "/login", "/logout"];
 
@@ -30,32 +28,21 @@ const AskMaestro = () => {
 				}}
 				onSubmit={async (values) => {
 					console.log(JSON.stringify(values));
-					const newChat = await fetch(
-						process.env.NEXT_PUBLIC_APIBASE + "/my/chats/",
+					const chat = await fetchApi(
+						"/my/chats/",
 						{
-							headers: {
-								"Content-type": "application/json",
-								Authorization: "Bearer " + jwt,
-							},
 							method: "POST",
-							body: JSON.stringify(values),
-							cache: "no-store",
+							body: JSON.stringify(values)
 						}
 					);
-					const chat = await newChat.json();
 					console.log(chat);
 					console.log(JSON.stringify({ chatId: chat.id, prompt: values.name }));
 					try {
-						const question = await fetch(
-							`${process.env.NEXT_PUBLIC_APIBASE}/chatbot/ask`,
+						const question = await fetchApi(
+							"/chatbot/ask",
 							{
-								headers: {
-									"Content-type": "application/json",
-									Authorization: "Bearer " + jwt,
-								},
 								method: "POST",
-								body: JSON.stringify({ chatId: chat.id, prompt: values.name }),
-								cache: "no-store",
+								body: JSON.stringify({ chatId: chat.id, prompt: values.name })
 							}
 						);
 					} catch (error) {

--- a/app/my/chats/_components/MobileChatsMenu.tsx
+++ b/app/my/chats/_components/MobileChatsMenu.tsx
@@ -1,16 +1,18 @@
 "use client";
 import { Dialog, Flex, Separator, Text } from "@radix-ui/themes";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { PiChatsDuotone } from "react-icons/pi";
 import MobileChatsLink from "./MobileChatsLink";
 import { fetchApi } from "@/app/utils/fetchInterceptor";
+import { useOnMount } from "@/app/utils/hooks/useOnMount";
 
 const MobileChatsMenu = () => {
 	const [chats, setChats] = useState<Chat[]>([]);
-	useEffect(() => {
+
+	useOnMount(() => {
 		fetchApi("/my/chats/")
 			.then((json) => setChats(json));
-	}, []);
+	});
 
 	return (
 		<Flex

--- a/app/my/chats/_components/MobileChatsMenu.tsx
+++ b/app/my/chats/_components/MobileChatsMenu.tsx
@@ -3,20 +3,12 @@ import { Dialog, Flex, Separator, Text } from "@radix-ui/themes";
 import React, { useEffect, useState } from "react";
 import { PiChatsDuotone } from "react-icons/pi";
 import MobileChatsLink from "./MobileChatsLink";
-import fetchInterceptor from "@/app/utils/fetchInterceptor";
-import { getCookie } from "cookies-next";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 
 const MobileChatsMenu = () => {
-	const jwt = getCookie("jwt");
 	const [chats, setChats] = useState<Chat[]>([]);
 	useEffect(() => {
-		fetch(`${process.env.NEXT_PUBLIC_APIBASE}/my/chats/`, {
-			method: "GET",
-			headers: {
-				Authorization: "Bearer " + jwt,
-			},
-		})
-			.then((response) => response.json())
+		fetchApi("/my/chats/")
 			.then((json) => setChats(json));
 	}, []);
 

--- a/app/my/chats/_components/NewChat.tsx
+++ b/app/my/chats/_components/NewChat.tsx
@@ -1,10 +1,12 @@
 "use client";
+
 import { Flex } from "@radix-ui/themes";
 import { getCookie } from "cookies-next";
 import { Field, Form, Formik } from "formik";
 import { useRouter } from "next/navigation";
 import React from "react";
 import { HiOutlineDocumentSearch } from "react-icons/hi";
+import { startNewChat } from "@/app/utils/api/chats";
 
 const NewChat = () => {
 	const router = useRouter();
@@ -15,24 +17,12 @@ const NewChat = () => {
 				initialValues={{
 					name: "",
 				}}
-				onSubmit={async (values) => {
-					console.log(JSON.stringify(values));
-					const newChat = await fetch(
-						process.env.NEXT_PUBLIC_APIBASE + "/my/chats/",
-						{
-							headers: {
-								"Content-type": "application/json",
-								Authorization: "Bearer " + jwt,
-							},
-							method: "POST",
-							body: JSON.stringify(values),
-							cache: "no-store",
-						}
-					);
-					const chatId = await newChat.json();
-					console.log(chatId);
-					router.push(`/my/chats/${chatId.id}`);
-					// if (newChat) redirect("/my/chats");
+				onSubmit={async ({ name: prompt }) => {
+					const chat = await startNewChat(prompt);
+
+					if (chat?.id) {
+						router.push(`/my/chats/${chat?.id}`);
+					}
 				}}
 			>
 				<Form className="w-[100%]">

--- a/app/my/chats/_components/SuggestedPrompt.tsx
+++ b/app/my/chats/_components/SuggestedPrompt.tsx
@@ -1,8 +1,9 @@
 "use client";
+import { fetchApi } from "@/app/utils/fetchInterceptor";
 import { Box, Card, Flex, Link, Text } from "@radix-ui/themes";
 import { getCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
-import React, { useEffect } from "react";
+import React from "react";
 import { FaMagic } from "react-icons/fa";
 import { FaCar, FaGamepad } from "react-icons/fa6";
 
@@ -18,32 +19,24 @@ const SuggestedPrompt = ({
 	const jwt = getCookie("jwt");
 	const router = useRouter();
 	const handleClick = (prompt: string, promptTitle: string) => () => {
-		fetch(`${process.env.NEXT_PUBLIC_APIBASE}/my/chats/`, {
+		fetchApi("/my/chats/", {
 			method: "POST",
 			headers: {
-				Accept: "application/json",
 				"Content-type": "application/json",
-				Authorization: "Bearer " + jwt,
 			},
 			body: JSON.stringify({ name: promptTitle }),
 		})
-			.then((response) => response.json())
 			.then((json) =>
-				fetch(`${process.env.NEXT_PUBLIC_APIBASE}/chatbot/ask/`, {
+				fetchApi("/chatbot/ask/", {
 					method: "POST",
 					headers: {
-						Accept: "application/json",
 						"Content-type": "application/json",
-						Authorization: "Bearer " + jwt,
 					},
 					body: JSON.stringify({ chatId: json.id, prompt: prompt }),
 				})
 			)
-			.then((response) => response.json())
-			.then((json) => {
-				console.log(json);
-				router.push(`/my/chats/${json.chatId}`);
-			});
+			.then((json) => console.log(json))
+			.then((json) => router.push(`/my/chats/${json.chatId}`));
 	};
 	return (
 		<Box

--- a/app/my/chats/_components/SuggestedPrompt.tsx
+++ b/app/my/chats/_components/SuggestedPrompt.tsx
@@ -1,11 +1,12 @@
 "use client";
-import { fetchApi } from "@/app/utils/fetchInterceptor";
+
 import { Box, Card, Flex, Link, Text } from "@radix-ui/themes";
 import { getCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useCallback } from "react";
 import { FaMagic } from "react-icons/fa";
 import { FaCar, FaGamepad } from "react-icons/fa6";
+import { startNewChat } from "@/app/utils/api/chats";
 
 const SuggestedPrompt = ({
 	promptTitle,
@@ -18,32 +19,20 @@ const SuggestedPrompt = ({
 }) => {
 	const jwt = getCookie("jwt");
 	const router = useRouter();
-	const handleClick = (prompt: string, promptTitle: string) => () => {
-		fetchApi("/my/chats/", {
-			method: "POST",
-			headers: {
-				"Content-type": "application/json",
-			},
-			body: JSON.stringify({ name: promptTitle }),
-		})
-			.then((json) =>
-				fetchApi("/chatbot/ask/", {
-					method: "POST",
-					headers: {
-						"Content-type": "application/json",
-					},
-					body: JSON.stringify({ chatId: json.id, prompt: prompt }),
-				})
-			)
-			.then((json) => console.log(json))
-			.then((json) => router.push(`/my/chats/${json.chatId}`));
-	};
+	const handleClick = useCallback(async () => {
+		const chat = await startNewChat(prompt, promptTitle);
+
+		if (chat?.id) {
+			router.push(`/my/chats/${chat?.id}`);
+		}
+	}, []);
+
 	return (
 		<Box
 			width="350px"
 			className="align-middle hover:scale-105 transition-all duration-200"
 		>
-			<Link onClick={handleClick(prompt, promptTitle)} color="gray">
+			<Link onClick={handleClick} color="gray">
 				<Card className="shadow-lg md:h-[150px] h-[80px] bg-slate-300 hover:bg-slate-100 duration-200">
 					<Flex
 						direction={{ initial: "row", md: "column" }}

--- a/app/mylibrary/loading.tsx
+++ b/app/mylibrary/loading.tsx
@@ -2,7 +2,6 @@ import { Box, Flex, Grid, Skeleton } from "@radix-ui/themes";
 import React from "react";
 import ArticleCard from "../articles/_components/ArticleCard";
 import FilterSideBar from "./FilterSideBar";
-import fetchInterceptor from "../utils/fetchInterceptor";
 
 const MyLibrary = async () => {
 	return (

--- a/app/utils/api/chats.ts
+++ b/app/utils/api/chats.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { toast } from "react-toastify";
+import { ClientError } from "./errors";
+import { fetchApi } from "../fetchInterceptor";
+
+export const createChat = (name: string): Promise<Chat> => fetchApi(
+    "/my/chats/",
+    {
+        method: "POST",
+        body: JSON.stringify({ name })
+    }
+);
+
+export const askChatbot = (chatId: string, prompt: string) => fetchApi(
+    "/chatbot/ask",
+    {
+        method: "POST",
+        body: JSON.stringify({ chatId, prompt })
+    }
+);
+
+export const startNewChat = async (prompt: string, promptTitle?: string) => {
+    try {
+        const chat = await createChat(promptTitle || prompt);
+        const chatId = chat?.id;
+
+        if (!chatId) {
+            toast.error('Chat could not be created');
+            console.error('Chat could not be created');
+            return;
+        }
+
+        await askChatbot(chatId, prompt);
+
+        return chat;
+    } catch (error) {
+        if (error instanceof ClientError) {
+            const errorMessage = `Failed to start chat: ${errors}`;
+            console.error(errorMessage);
+            toast.error(errorMessage);
+        }
+    }
+}

--- a/app/utils/api/errors.ts
+++ b/app/utils/api/errors.ts
@@ -1,0 +1,20 @@
+export class ApiError extends Error {
+	public status: number;
+	public statusText: string;
+	public body?: object | string;
+
+	constructor(res: Response, data: object, pathname: string) {
+		const { status, statusText } = res;
+		super(`ApiError: ${status} ${statusText} fetching ${pathname}`);
+		this.status = status;
+		this.statusText = statusText;
+
+		try {
+			this.body = data;
+		} catch (error) {}
+	}
+}
+export class ClientError extends ApiError {}
+export class ServerError extends ApiError {}
+export class OfflineError extends Error {}
+export class ServerConnectionError extends Error {}

--- a/app/utils/fetchInterceptor.ts
+++ b/app/utils/fetchInterceptor.ts
@@ -1,20 +1,56 @@
-import { cookies } from "next/headers";
+import { getCookie } from "./cookies";
+import { toast } from 'react-toastify';
+import { 
+	ServerConnectionError,
+	OfflineError,
+	ServerError,
+	ClientError
+} from './api/errors'
 
-const fetchInterceptor = async (url: string) => {
-  const jwt = await (await cookies()).get("jwt")
-  const data = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-      Authorization:
-        "Bearer " + jwt?.value ,
-    },
-    cache: "no-store"
-  });
-  const res = await data.json();
-  return (res);
-}
+const fetchInterceptor = async (url: string, options?: RequestInit) => {
+	let res;
+	let data;
+	const { pathname } = new URL(url);
+	const resource = pathname.replace(/\/$/, '').split('/').pop();
 
-export default fetchInterceptor;
+	try {
+		const jwt = await getCookie("jwt");
+		res = await fetch(url, {
+			...options,
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/json",
+				Authorization: jwt ? "Bearer " + jwt : '',
+				...options?.headers
+			},
+			cache: "no-store"
+		});
+		data = await res.json();
+	} catch (error) {
+		console.error(`Fetch request failed ${url}`, error);
+		if (navigator.onLine) {
+			toast.error('Server seems to be offline');
+			throw new ServerConnectionError();
+		} else {
+			toast.error('No internet connection');
+			throw new OfflineError();
+		}
+	}
 
-export const fetchApi = (url: string) =>
-  fetchInterceptor(`${process.env.NEXT_PUBLIC_APIBASE}${url}`);
+	const status = res?.status;
+
+	if (status >= 500) {
+		toast.error(`Server error for ${resource}: ${res.status} ${res.statusText}`);
+		console.error('500 error', data, res);
+		throw new ServerError(res, data, pathname);
+	}
+
+	if (status >= 400) {
+		throw new ClientError(res, data, pathname);
+	}
+
+	return data;
+};
+
+export const fetchApi = (url: string, options?: RequestInit) =>
+	fetchInterceptor(`${process.env.NEXT_PUBLIC_APIBASE}${url}`, options);

--- a/app/utils/hooks/useOnMount.ts
+++ b/app/utils/hooks/useOnMount.ts
@@ -1,0 +1,4 @@
+import type { EffectCallback } from "react";
+import { useEffect } from "react";
+
+export const useOnMount = (fn: EffectCallback) => useEffect(fn, []);

--- a/app/utils/type.ts
+++ b/app/utils/type.ts
@@ -101,8 +101,12 @@ interface JobTitle {
 }
 
 interface Chat {
-	id: String;
-	name: String;
+	id: string;
+	name: string;
+	createdAt: string;
+	deletedAt: string | null;
+	updatedAt: string;
+	userId: string;
 }
 
 interface Message{


### PR DESCRIPTION
Note that this shares the first 3 commits with MR https://github.com/medideas/maestrov2/pull/3 -  depending on which one is merged first, the other might need to be rebased interactively on `main` and ensure no duplicates exist in the todo.

## 071f48b Add error handling to fetch & enable client use

This adds various error handling to the fetchApi/Interceptor, such as
throwing errors if the server returns an error and showing a toaster
message with the error. However, client errors are just thrown and need
to be handled on a case-by-case basis, depending on how the error should
be presented to the user.

This also enables using the `fetchApi` in client components, as the
isomorphic cookie utility is used.

## 99e8984 Use fetchApi for client requests as well

Use the fetchApi utility for chats, even though they are client
components.

## cce7748 Prevent own DDoS attack on the API

In the mobile view, the `MobileChatsMenu` fetches list of the chats in
a `useEffect` hook. As the `useEffect` hook doesn't have any dependency
array, it will run on each render. Each render will trigger a new fetch
and each fetch sets the `chats` state, which triggers a new render.

This causes an infinite loop that calls the `/my/chats` API. In a
production scenario, several mobile visitors to the `/my/chats` page
could basically cause a Distributed Denial of Service attack against the
API by unsuspecting, legitimate users.

This creates a `useOnMount` hook that will only run once per component
mount. While super simple, it introduces a reusable concept that can
prevent this issue in the future.

![mobile-chats-fetching-loop](https://github.com/user-attachments/assets/f0abd858-eb2b-4bc8-bdcc-13b655273da9)

## 870f11a Unify chat APIs & add error handling

Similar code was used in the components `<SuggestedPrompt>`,
`<NewChat>`, `<Chatbot>` and `<AskMaestro>` components for starting a
chat and asking the chatbot a question. This code has been unified into
a single chat API utility, which is then used in all these components.
Only the redirecting logic is left in each component, as it is a view
layer concern that requires access to the router.

In addition to the existing `fetchInterceptor` error handling, this
handles client errors by showing a toast with the error message returned
by the server. This also ensure to guard for the case of there not being
any chat ID and in that case to not redirect the user to
`/my/chats/undefined`.

# Examples of errors

<img width="374" alt="Screenshot 2024-12-21 at 16 24 27" src="https://github.com/user-attachments/assets/9050130d-4486-4f18-9bcd-198fa9efb8ce" />

<img width="340" alt="Screenshot 2024-12-21 at 16 32 48" src="https://github.com/user-attachments/assets/9222b1c9-b9aa-4afa-9d5a-77cf4139980d" />

<img width="378" alt="Screenshot 2024-12-21 at 16 25 53" src="https://github.com/user-attachments/assets/da445b3a-55e9-46cf-9aff-235c86fc3e57" />

<img width="382" alt="Screenshot 2024-12-21 at 16 34 17" src="https://github.com/user-attachments/assets/5e7f2240-aabf-44c0-8857-5d1ffc4bc05e" />

<img width="1014" alt="Screenshot 2024-12-21 at 12 54 30" src="https://github.com/user-attachments/assets/8bf06683-0688-4b22-982f-6de7ed36513f" />