### PR TITLE
Desktop nav links styling fix

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -84,7 +84,7 @@ select {
 	/* Make them block level
        and only as wide as they need */
 	float: left;
-	padding: 10px 30px;
+	padding: 10px 20px;
 	text-decoration: none;
 	font-size: 15px;
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -153,8 +153,8 @@ select {
 /* Circles */
 .tabs li a:after,
 .tabs li a:before {
-	width: 30px;
-	height: 30px;
+	width: 20px;
+	height: 20px;
 	/* Circles are circular */
 	-webkit-border-radius: 15px;
 	-moz-border-radius: 15px;
@@ -175,10 +175,10 @@ select {
 	background: #ece5e0;
 }
 .tabs li a:before {
-	left: -30px;
+	left: -20px;
 }
 .tabs li a:after {
-	right: -30px;
+	right: -20px;
 }
 
 .tabs li a:after :last-of-type {


### PR DESCRIPTION

## 75ccdeb Improve DesktopNavLinks inverted rounded corners

The overlayed circle that melt into the background color to make the inverted rounded white corners between the navigation link/item and the page below, are larger than they should be, resulting in a jagged line and risk overlaying the adjacent menu items.

This decreases the size of these circles to 20px, meaning a radius of 10px that match the 10px size of the white square. This results in a smoother rounded corner.

### Highlighted change/diff

#### Before

<img width="870" alt="Screenshot 2024-12-22 at 21 33 14" src="https://github.com/user-attachments/assets/e2761553-6b2d-4758-932a-2b5a651516fd" />

#### After

<img width="789" alt="Screenshot 2024-12-22 at 21 33 47" src="https://github.com/user-attachments/assets/0f8a28e2-0898-4be8-9d75-d184c6db11e4" />

### Actual visuals

#### Before

Note how the inverted rounded corners are not perfectly round, but a bit jagged

<img width="873" alt="Screenshot 2024-12-22 at 21 32 39" src="https://github.com/user-attachments/assets/704bf395-5233-4316-9d8e-9256ff8413ae" />

#### After

<img width="781" alt="Screenshot 2024-12-22 at 21 11 03" src="https://github.com/user-attachments/assets/e1e1b025-d75d-4d8d-9132-3cbd3958fe19" />

## 957c114 Decrease DesktopNavLinks width

Decrease the desktop navigation link/item horizontal padding by 33% to ensure all menu items fit even on a narrow viewport (768-868px width) without wrapping onto a new line, which looks weird, as the menu items are designed to be attached to the page below.

### Actual visuals

#### Before

Looks a bit broken

<img width="772" alt="Screenshot 2024-12-22 at 21 55 59" src="https://github.com/user-attachments/assets/c8a19783-2e5f-4168-866b-b07ee77a46de" />

#### After

<img width="779" alt="Screenshot 2024-12-22 at 21 55 27" src="https://github.com/user-attachments/assets/d4557226-059c-4b69-b4c5-d12842bc7707" />