### PR TITLE
Show help menu & simplify roles check

### DIFF
--- a/app/components/navbar/DesktopNavLinks.tsx
+++ b/app/components/navbar/DesktopNavLinks.tsx
@@ -26,7 +26,7 @@ const DesktopNavLinks = ({ roles }: { roles: string[] }) => {
 			<ul className="flex-col tabs group">
 				{links.map(
 					(link) =>
-						isUserAllowed(roles, link.label) && (
+						isUserAllowed(roles, link.for) && (
 							<li
 								key={link.href}
 								className={

--- a/app/components/navbar/MobileNavLinks.tsx
+++ b/app/components/navbar/MobileNavLinks.tsx
@@ -42,7 +42,7 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 					<ul className="flex-col flex-1 text-right">
 						{links.map(
 							(link) =>
-								isUserAllowed(roles, link.label) && (
+								isUserAllowed(roles, link.for) && (
 									<li key={link.href} className="py-2 pr-5">
 										<Link
 											href={link.href}
@@ -57,7 +57,6 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 										</Link>
 									</li>
 								)
-							// )
 						)}
 						<li className="py-2 pr-5">
 							<Link

--- a/app/utils/isUserAllowed.ts
+++ b/app/utils/isUserAllowed.ts
@@ -1,45 +1,12 @@
-const isUserAllowed = (roles: string[], url: string) => {
-    let result = false;
-    if (url === "Manage users" && roles.includes("User Manager")) {
-        result = true;
-        return result;
+const isUserAllowed = (userRoles: string[], allowedRoles: string[] | string) => {
+    if (allowedRoles == "all") {
+        return true;
+    } else if (typeof allowedRoles == "string") {
+        return userRoles.includes(allowedRoles);
+    } else if (Array.isArray(allowedRoles)) {
+        return userRoles.some(role => allowedRoles.includes(role));
     }
-    if (url === "Content" && roles.includes("Editor")) {
-        result = true;
-        return result;
-    }
-    if (url === "Home" && roles.includes("Learner")) {
-        result = true;
-        return result;
-    }
-    if (
-        url === "My Profile" &&
-        (roles.includes("Learner") || roles.includes("Editor"))
-    ) {
-        result = true;
-        return result;
-    }
-    if (url === "Library" && roles.includes("Learner")) {
-        result = true;
-        return result;
-    }
-    if (
-        url === "ChatMaestro" &&
-        (roles.includes("Learner") ||
-            roles.includes("Editor") ||
-            roles.includes("User Manager"))
-    ) {
-        result = true;
-        return result;
-    }
-    if (
-        url === "Help" &&
-        (roles.includes("Learner") ||
-            roles.includes("Editor") ||
-            roles.includes("User Manager"))
-    ) {
-        result = true;
-        return result;
-    }
+
+    return false;
 };
 export default isUserAllowed;

--- a/app/utils/navlink.ts
+++ b/app/utils/navlink.ts
@@ -2,27 +2,27 @@ const links = [
     {
         label: "Home",
         href: "/home",
-        for: "all",
+        for: "Learner",
     },
     {
         label: "My Profile",
         href: "/my/profile",
-        for: "all",
+        for: ["Learner", "Editor"],
     },
     {
         label: "ChatMaestro",
         href: "/my/chats",
-        for: "all",
+        for: ["Learner", "Editor", "User Manager"],
     },
     {
         label: "Library",
         href: "/mylibrary",
-        for: "all",
+        for: "Learner",
     },
     {
         label: "Manage users",
         href: "/users",
-        for: "User Manager",
+        for: ["User Manager"],
     },
     {
         label: "Content",


### PR DESCRIPTION
The issue is that the "Help" url/route is not referenced in the `isUserAllowed` utility. However, rather than just adding it, let's use the `for` property of the links to determine a user's permissions to access a specific page.

The `for` property of the links is updated to match the `isUserAllowed` utility, while the `isUserAllowed` utility is made to handle not only single user role matching, but allowing matching several user roles against several permissible roles (`allowedRoles`) in addition to accepting a single string role or `all` that permits all users to access the URL.

# Menu items now shown for each role

## Learner

<img width="572" alt="Screenshot 2024-12-23 at 23 15 25" src="https://github.com/user-attachments/assets/7a5502a0-e514-47fa-b147-893126407b2f" />

## User Manager

<img width="441" alt="Screenshot 2024-12-23 at 23 15 37" src="https://github.com/user-attachments/assets/a2388b8e-0a2a-4131-9bae-b22b0f9bbc40" />

## Editor

<img width="496" alt="Screenshot 2024-12-23 at 23 15 50" src="https://github.com/user-attachments/assets/111a5b85-001c-4fd7-baaa-9a9d6e103df2" />
