### PR TITLE
Use Radix Dialog for MobileNavLinks menu

### DIFF
--- a/app/Navbar.tsx
+++ b/app/Navbar.tsx
@@ -18,8 +18,8 @@ const Navbar = async () => {
 		userRoles.map((r) => roles.push(r.role.name));
 		return (
 			<nav className="p-0 m-0 overflow-x-hidden">
-				<Flex direction="column">
-					<Flex justify="between" className="bg-navbar p-5">
+				<Flex direction={{ initial: "row", sm: "column" }} justify="between" align={{ initial: "center", sm: "end" }} className="bg-navbar">
+					<Flex justify="between" className="p-5 w-full">
 						<Flex display={{ initial: "none", sm: "flex" }}>
 							<AvatarBox user={loggedUser} />
 						</Flex>
@@ -37,14 +37,12 @@ const Navbar = async () => {
 					<Flex
 						display={{ initial: "none", sm: "flex" }}
 						justify="end"
-						className="bg-navbar"
 					>
 						<DesktopNavLinks roles={roles} />
 					</Flex>
 					<Flex
 						display={{ initial: "flex", sm: "none" }}
 						justify="end"
-						className="bg-navbar"
 					>
 						<MobileNavLinks user={loggedUser} roles={roles} />
 					</Flex>

--- a/app/components/DefaultTheme.tsx
+++ b/app/components/DefaultTheme.tsx
@@ -1,0 +1,9 @@
+import { Theme } from "@radix-ui/themes";
+
+export const DefaultTheme = ({ children, ...props }: { children: React.ReactNode }) => {
+	return (
+		<Theme accentColor="red" radius="small" appearance="light" {...props}>
+			{children}
+		</Theme>
+	);
+};

--- a/app/components/navbar/AvatarBox.tsx
+++ b/app/components/navbar/AvatarBox.tsx
@@ -1,16 +1,9 @@
 "use client";
-import { Avatar, Button, Dialog, Flex, Heading, Box } from "@radix-ui/themes";
+import { Avatar, Flex, Heading, Box } from "@radix-ui/themes";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import React from "react";
 
-type User = {
-	firstName: String;
-};
-
 const AvatarBox = ({ user }: { user: User }) => {
-	const currentPath = usePathname();
-	const currentLink = (url: string, path: string) => {};
 	return (
 		<Flex align="center" mt="3" ml="4">
 			<Link href={`/my/profile`}>

--- a/app/components/navbar/DesktopNavLinks.tsx
+++ b/app/components/navbar/DesktopNavLinks.tsx
@@ -22,7 +22,7 @@ const DesktopNavLinks = ({ roles }: { roles: string[] }) => {
 	let userIsLoggedIn = true;
 
 	return (
-		<div>
+		<nav>
 			<ul className="flex-col tabs group">
 				{links.map(
 					(link) =>
@@ -55,7 +55,7 @@ const DesktopNavLinks = ({ roles }: { roles: string[] }) => {
 					</Link>
 				</li>
 			</ul>
-		</div>
+		</nav>
 	);
 };
 

--- a/app/components/navbar/DesktopNavLinks.tsx
+++ b/app/components/navbar/DesktopNavLinks.tsx
@@ -1,11 +1,9 @@
 "use client";
-import { Flex, Box, Heading, Avatar } from "@radix-ui/themes";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React, { useState } from "react";
 import classnames from "classnames";
 import links from "../../utils/navlink";
-import { boolean } from "yup";
 import isUserAllowed from "@/app/utils/isUserAllowed";
 
 const currentNavLink = function (url: string, linkPath: string) {
@@ -17,9 +15,7 @@ const currentNavLink = function (url: string, linkPath: string) {
 };
 
 const DesktopNavLinks = ({ roles }: { roles: string[] }) => {
-	const [isOpen, setOpen] = useState(false);
 	const currentPath = usePathname();
-	let userIsLoggedIn = true;
 
 	return (
 		<nav>

--- a/app/components/navbar/MobileNavLinks.tsx
+++ b/app/components/navbar/MobileNavLinks.tsx
@@ -1,13 +1,15 @@
 "use client";
 import { Flex, Box, Heading, Avatar } from "@radix-ui/themes";
+import * as Dialog from "@radix-ui/react-dialog";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import classnames from "classnames";
 import links from "../../utils/navlink";
 import AvatarBox from "./AvatarBox";
 import { SlClose, SlMenu } from "react-icons/sl";
 import isUserAllowed from "@/app/utils/isUserAllowed";
+import styles from "./mobile-nav-links.module.css";
 
 type User = {
 	firstName: String;
@@ -15,63 +17,102 @@ type User = {
 
 const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 	const [isOpen, setOpen] = useState(false);
+	const [shouldRender, setRender] = useState(false);
 	const currentPath = usePathname();
-	let userIsLoggedIn = true;
+
+	useEffect(() => {
+		// Close open menu if viewport is resized from mobile to desktop
+		const mediaQueryList = window.matchMedia("(min-width: 768px)");
+		const handleChange = (event: MediaQueryListEvent) => {
+			if (event.matches) {
+				setOpen(false);
+				setRender(false);
+			}
+		};
+		mediaQueryList.addEventListener("change", handleChange);
+
+		return () => mediaQueryList.removeEventListener("change", handleChange);
+	}, []);
+
+	useEffect(() => {
+		if (isOpen) {
+			setRender(true);
+		}
+	}, [isOpen]);
+
+	const onAnimationEnd = useCallback(() => {
+		// Delay removing the menu from the DOM until the exit animation is complete
+		if (!isOpen) {
+			setRender(false);
+		}
+	}, [isOpen]);
+
 	return (
-		<div>
-			{/* mobile menu */}
-			<Flex px="5" pb="5" className="absolute top-10 right-10">
-				<SlMenu
-					size="30"
-					className={isOpen ? "hidden" : "md:hidden visible"}
-					onClick={() => setOpen(!isOpen)}
-				/>
-				<SlClose
-					size="30"
-					className={isOpen ? "visible" : "hidden"}
-					onClick={() => setOpen(!isOpen)}
-				/>
-			</Flex>
-			<div
-				className={` md:hidden bg-navbar h-dvh w-[85%] shadow-xl absolute z-10 left-[-500px] transition-all duration-700 ease-in-out ${
-					isOpen && "left-[0px]"
-				}`}
-			>
-				<AvatarBox user={user} />
-				<Flex pb="5">
-					<ul className="flex-col flex-1 text-right">
-						{links.map(
-							(link) =>
-								isUserAllowed(roles, link.for) && (
-									<li key={link.href} className="py-2 pr-5">
+		<Dialog.Root open={isOpen} onOpenChange={setOpen}>
+			<>
+				<Dialog.Trigger asChild>
+					<Flex px="5" pb="5" className="absolute top-10 right-10">
+						<SlMenu
+							size="30"
+							className={isOpen ? "hidden" : "md:hidden visible"}
+						/>
+						<SlClose size="30" className={isOpen ? "visible" : "hidden"} />
+					</Flex>
+				</Dialog.Trigger>
+				<Dialog.Portal forceMount>
+					{shouldRender && (
+						<Dialog.Overlay
+							className={`fixed w-full h-full ${isOpen ? "block" : "hidden"}`}
+						/>
+					)}
+					{shouldRender && (
+						<Dialog.Content
+							className={`md:hidden bg-navbar h-dvh w-[85%] shadow-xl absolute ${
+								styles.content
+							} ${isOpen ? styles.contentShow : styles.contentHide}`}
+							onAnimationEnd={onAnimationEnd}
+							onOpenAutoFocus={(event) => event.preventDefault()}
+						>
+							<Dialog.Title>Site Menu</Dialog.Title>
+							<Dialog.Description>Site Menu</Dialog.Description>
+							<AvatarBox user={user} />
+							<Flex pb="5">
+								<ul className="flex-col flex-1 text-right">
+									{links.map(
+										(link) =>
+											isUserAllowed(roles, link.label) && (
+												<li key={link.href} className="py-2 pr-5">
+													<Link
+														href={link.href}
+														className={classnames({
+															"text-red-800": link.href === currentPath,
+															"text-zinc-500": link.href != currentPath,
+															"font-semibold text-l": true,
+														})}
+														onClick={() => setOpen(false)}
+													>
+														{link.label}
+													</Link>
+												</li>
+											)
+									)}
+									<li className="py-2 pr-5">
 										<Link
-											href={link.href}
+											href="/logout"
 											className={classnames({
-												"text-red-800": link.href === currentPath,
-												"text-zinc-500": link.href != currentPath,
 												"font-semibold text-l": true,
 											})}
-											onClick={() => setOpen(!isOpen)}
 										>
-											{link.label}
+											Logout
 										</Link>
 									</li>
-								)
-						)}
-						<li className="py-2 pr-5">
-							<Link
-								href="/logout"
-								className={classnames({
-									"font-semibold text-l": true,
-								})}
-							>
-								Logout
-							</Link>
-						</li>
-					</ul>
-				</Flex>
-			</div>
-		</div>
+								</ul>
+							</Flex>
+						</Dialog.Content>
+					)}
+				</Dialog.Portal>
+			</>
+		</Dialog.Root>
 	);
 };
 

--- a/app/components/navbar/MobileNavLinks.tsx
+++ b/app/components/navbar/MobileNavLinks.tsx
@@ -48,13 +48,13 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 		<Dialog.Root open={isOpen} onOpenChange={setOpen}>
 			<>
 				<Dialog.Trigger asChild>
-					<Flex px="5" pb="5" className="absolute top-10 right-10">
+					<button type="button" className="p-5">
 						<SlMenu
 							size="30"
 							className={isOpen ? "hidden" : "md:hidden visible"}
 						/>
 						<SlClose size="30" className={isOpen ? "visible" : "hidden"} />
-					</Flex>
+					</button>
 				</Dialog.Trigger>
 				<Dialog.Portal forceMount>
 					{shouldRender && (
@@ -64,7 +64,7 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 					)}
 					{shouldRender && (
 						<Dialog.Content
-							className={`md:hidden bg-navbar h-dvh w-[85%] shadow-xl absolute ${
+							className={`md:hidden bg-navbar h-dvh w-[85%] shadow-xl absolute p-5 ${
 								styles.content
 							} ${isOpen ? styles.contentShow : styles.contentHide}`}
 							onAnimationEnd={onAnimationEnd}
@@ -76,12 +76,12 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 							</Dialog.Description>
 							<DefaultTheme hasBackground={false}>
 								<AvatarBox user={user} />
-								<Flex pb="5">
+								<nav>
 									<ul className="flex-col flex-1 text-right">
 										{links.map(
 											(link) =>
 												isUserAllowed(roles, link.label) && (
-													<li key={link.href} className="py-2 pr-5">
+													<li key={link.href} className="py-2">
 														<Link
 															href={link.href}
 															className={classnames({
@@ -96,7 +96,7 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 													</li>
 												)
 										)}
-										<li className="py-2 pr-5">
+										<li className="py-2">
 											<Link
 												href="/logout"
 												className={classnames({
@@ -107,7 +107,7 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 											</Link>
 										</li>
 									</ul>
-								</Flex>
+								</nav>
 							</DefaultTheme>
 						</Dialog.Content>
 					)}

--- a/app/components/navbar/MobileNavLinks.tsx
+++ b/app/components/navbar/MobileNavLinks.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Flex, Box, Heading, Avatar } from "@radix-ui/themes";
+import { Flex } from "@radix-ui/themes";
 import * as Dialog from "@radix-ui/react-dialog";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -10,10 +10,6 @@ import AvatarBox from "./AvatarBox";
 import { SlClose, SlMenu } from "react-icons/sl";
 import isUserAllowed from "@/app/utils/isUserAllowed";
 import styles from "./mobile-nav-links.module.css";
-
-type User = {
-	firstName: String;
-};
 
 const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 	const [isOpen, setOpen] = useState(false);

--- a/app/components/navbar/MobileNavLinks.tsx
+++ b/app/components/navbar/MobileNavLinks.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React, { useState, useEffect, useCallback } from "react";
 import classnames from "classnames";
+import { DefaultTheme } from "../DefaultTheme";
 import links from "../../utils/navlink";
 import AvatarBox from "./AvatarBox";
 import { SlClose, SlMenu } from "react-icons/sl";
@@ -69,41 +70,45 @@ const MobileNavLinks = ({ roles, user }: { roles: string[]; user: User }) => {
 							onAnimationEnd={onAnimationEnd}
 							onOpenAutoFocus={(event) => event.preventDefault()}
 						>
-							<Dialog.Title>Site Menu</Dialog.Title>
-							<Dialog.Description>Site Menu</Dialog.Description>
-							<AvatarBox user={user} />
-							<Flex pb="5">
-								<ul className="flex-col flex-1 text-right">
-									{links.map(
-										(link) =>
-											isUserAllowed(roles, link.label) && (
-												<li key={link.href} className="py-2 pr-5">
-													<Link
-														href={link.href}
-														className={classnames({
-															"text-red-800": link.href === currentPath,
-															"text-zinc-500": link.href != currentPath,
-															"font-semibold text-l": true,
-														})}
-														onClick={() => setOpen(false)}
-													>
-														{link.label}
-													</Link>
-												</li>
-											)
-									)}
-									<li className="py-2 pr-5">
-										<Link
-											href="/logout"
-											className={classnames({
-												"font-semibold text-l": true,
-											})}
-										>
-											Logout
-										</Link>
-									</li>
-								</ul>
-							</Flex>
+							<Dialog.Title className="sr-only">Site Menu</Dialog.Title>
+							<Dialog.Description className="sr-only">
+								Site Menu
+							</Dialog.Description>
+							<DefaultTheme hasBackground={false}>
+								<AvatarBox user={user} />
+								<Flex pb="5">
+									<ul className="flex-col flex-1 text-right">
+										{links.map(
+											(link) =>
+												isUserAllowed(roles, link.label) && (
+													<li key={link.href} className="py-2 pr-5">
+														<Link
+															href={link.href}
+															className={classnames({
+																"text-red-800": link.href === currentPath,
+																"text-zinc-500": link.href != currentPath,
+																"font-semibold text-l": true,
+															})}
+															onClick={() => setOpen(false)}
+														>
+															{link.label}
+														</Link>
+													</li>
+												)
+										)}
+										<li className="py-2 pr-5">
+											<Link
+												href="/logout"
+												className={classnames({
+													"font-semibold text-l": true,
+												})}
+											>
+												Logout
+											</Link>
+										</li>
+									</ul>
+								</Flex>
+							</DefaultTheme>
 						</Dialog.Content>
 					)}
 				</Dialog.Portal>

--- a/app/components/navbar/mobile-nav-links.module.css
+++ b/app/components/navbar/mobile-nav-links.module.css
@@ -1,0 +1,37 @@
+.content {
+	position: absolute;
+	overflow-y: auto;
+	width: 85vw;
+	max-width: 350px;
+	left: -90vw;
+	animation-duration: 500ms;
+	animation-timing-function: ease-in-out;
+	animation-fill-mode: forwards;
+}
+
+.content:focus {
+	outline: none;
+}
+
+.contentShow {
+	animation-name: contentShow;
+}
+
+.contentHide {
+	animation-name: contentHide;
+}
+
+@keyframes contentShow {
+	to {
+		left: 0;
+	}
+}
+
+@keyframes contentHide {
+	from {
+		left: 0;
+	}
+	to {
+		left: -90vw;
+	}
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,10 +3,11 @@ import 'react-toastify/dist/ReactToastify.css';
 import "./globals.css";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import { Flex, Box, Grid, Section, Theme, Text } from "@radix-ui/themes";
+import { Flex, Box, Grid, Section, Text } from "@radix-ui/themes";
 import Navbar from "./Navbar";
 import { Suspense } from "react";
 import { ToastContainer } from "react-toastify";
+import { DefaultTheme } from "./components/DefaultTheme";
 
 export const metadata: Metadata = {
 	title: "Maestro",
@@ -24,7 +25,7 @@ export default async function RootLayout({
 		<html lang="en" className="dm_sans.className">
 			<body className={"flex flex-col m-0 p-0"}>
 				<ToastContainer />
-				<Theme accentColor="red" radius="small" appearance="light">
+				<DefaultTheme>
 					<Navbar />
 					<main className="flex-auto min-h-[80vh]">
 						<Suspense>{children}</Suspense>
@@ -47,7 +48,7 @@ export default async function RootLayout({
 							<Box></Box>
 						</Grid>
 					</Section>
-				</Theme>
+				</DefaultTheme>
 			</body>
 		</html>
 	);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,10 +5,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { Flex, Box, Grid, Section, Theme, Text } from "@radix-ui/themes";
 import Navbar from "./Navbar";
-import AskMaestro from "./components/AskMaestro";
-import { fetchApi } from "./utils/fetchInterceptor";
 import { Suspense } from "react";
-import NewChat from "./my/chats/_components/NewChat";
 import { ToastContainer } from "react-toastify";
 
 export const metadata: Metadata = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.1",
+        "@radix-ui/react-dialog": "^1.1.3",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^3.1.6",
         "ag-grid-react": "^32.3.3",
@@ -970,6 +971,42 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz",
@@ -1202,22 +1239,22 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
-      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.3.tgz",
+      "integrity": "sha512-ujGvqQNkZ0J7caQyl8XuZRj2/TIrYcOGwqz5TeD1OMcCdfBuEMP0D12ve+8J5F9XuNUth3FAKFWo/wt0E/GJrQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.2",
         "@radix-ui/react-focus-guards": "1.1.1",
-        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-portal": "1.1.2",
-        "@radix-ui/react-presence": "1.1.1",
-        "@radix-ui/react-primitive": "2.0.0",
-        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "aria-hidden": "^1.1.1",
         "react-remove-scroll": "2.6.0"
@@ -1233,6 +1270,168 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.2.tgz",
+      "integrity": "sha512-kEHnlhv7wUggvhuJPkyw4qspXLJOdYoAP4dO2c8ngGuXTq1w/HZp1YeVB+NQ2KbH1iEG+pvOCGYSqh9HZOz6hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz",
+      "integrity": "sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
+      "integrity": "sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.1",
+    "@radix-ui/react-dialog": "^1.1.3",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.1.6",
     "ag-grid-react": "^32.3.3",


### PR DESCRIPTION
## 0aa0b5f Use Radix Dialog for MobileNavLinks menu

This switches to use the Radix Dialog for the mobile navigation menu. This has several benefits:

- Places the menu in a portal independent of relative positioning of the rest of the page elements, which in turn
- Fixes the bug where the menu is visible despite being closed in the viewports widths 586px-767px:
  
  ![WhatsApp Image 2024-12-15 at 14 42 33](https://github.com/user-attachments/assets/d27c8801-1836-4b5d-91b5-f93ec3fcd3f3)

- Enables clicking the outside the menu to close it
- Enables styling the backdrop if desired
- Closes the menu when changing from mobile to desktop viewport width
- Adds accessibility, such as closing menu by pressing the [Esc] key and using a `<button>` for the trigger to open/close the menu.
- Disables page scroll except if the menu doesn't fit the viewport width or height.
- Improves semantics by using `<nav>` for menu links and `<button>` for the menu open/close trigger.

## b16d9c8 Create default theme component

The default theme can be used in several places with the same default theme configuration without repetition.

## 1324f6f Fix broken styling in mobile nav menu

When using the Radix Dialog, it creates a Portal, which is placed outside the normal react mounting point and therefore also outside the root layout `<Theme>`.

This wraps the dialog content in the same default theme as the root layout. This particularly fixes the `<AvatarBox>` styling, that was completely lacking.

## abcddb8 Improve mobile nav trigger positioning

The button to open the mobile menu was not vertically centered, as it used absolute positioning. This positions the menu trigger button vertically as part of the parent flex layout.


# Screenshots

## Before

![localhost_3000_home (1)](https://github.com/user-attachments/assets/e163537a-d9d9-4393-97b0-3808a801f1c4)

## After

![localhost_3000_home (2)](https://github.com/user-attachments/assets/f8e62f89-0608-4656-a3c5-4e40eea40284)

# Screen recording

## Before

https://github.com/user-attachments/assets/873e5e5d-9586-486c-a944-0cc4094defa8

## After

https://github.com/user-attachments/assets/abcf7e01-69f9-40ac-88fa-436e19832911
